### PR TITLE
Added function to reset scroller. I am using niceScroll in a drag/drop p...

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -8,6 +8,15 @@
 --
 */
 
+
+function resetniceScroll(element) {
+        $('.Scroller').remove();
+        $(element).removeAttr('style');
+        $(element).removeAttr('tabindex');
+        $(element).data('__nicescroll', 0);
+        $(element).niceScroll({});
+    }
+
 (function($){
 
   // globals
@@ -313,6 +322,7 @@
         
         var rail = $(document.createElement('div'));
         rail.attr('id',self.id);
+        rail.attr('class','Scroller');
         rail.width = 3+Math.max(parseFloat(self.opt.cursorwidth),cursor.outerWidth());
         rail.css({"padding-left":"0px","padding-right":"1px",width:rail.width+"px",'zIndex':(self.ispage)?self.opt.zindex:self.opt.zindex+2,"background":self.opt.background});
         


### PR DESCRIPTION
...anel scenario and any action that changes the panel breaks the scroller. If I minimize the panel, close it, add a new panel or move a panel the scroller artifact stays behind in the original location.

My proposal is to add a class to the scroller and add a function to reset that effectively undoes what the binding call adds and then refires the binding call. 

See these examples - be sure to drag/drop move a panel to see the broken and fixed versions.

http://ericcoffman.net/panels/broken.html
http://ericcoffman.net/panels/fixed.html
