### PR TITLE
hiden scrollbar when main content is invisible

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -1415,6 +1415,7 @@
             self.railh&&self.railh.css({"cursor":"default"});          
           
             self.jqbind(self.rail,"mouseenter",function() {
+              if (!self.win.is(":visible")) return false
               if (self.canshowonmouseevent) self.showCursor();
               self.rail.active = true;
             });
@@ -1432,6 +1433,7 @@
 
             if (self.railh) {
               self.jqbind(self.railh,"mouseenter",function() {
+                if (!self.win.is(":visible")) return false
                 if (self.canshowonmouseevent) self.showCursor();
                 self.rail.active = true;
               });          


### PR DESCRIPTION
I am use nicescroll with collapse element, the element show after I click a link, I find that when the element hide, the scrollbar will still show if I move mouse to scrollbar position, this hot fix solve my problem and I hope can help others

btw, you'v write a great software 
