### PR TITLE
tabindex

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -22,7 +22,7 @@
   var domfocus = false;
   var mousefocus = false;
   var zoomactive = false;
-  var tabindexcounter = 5000;
+  var tabindexcounter = 0;
   var ascrailcounter = 2000;
   var globalmaxzindex = 0;
   


### PR DESCRIPTION
`tabindex` must be `0` to keep natural tabbing flow.

http://snook.ca/archives/accessibility_and_usability/elements_focusable_with_tabindex
