### PR TITLE
Fixed bug: cantouch capability is detected as a false positive in WebKitGTK+

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -338,8 +338,8 @@
     
     this.istouchcapable = false;  // desktop devices with touch screen support
     
-//## Check Chrome desktop with touch support
-    if (cap.cantouch&&cap.ischrome&&!cap.isios&&!cap.isandroid) {
+//## Check WebKit-based desktop with touch support
+    if (cap.cantouch&&cap.iswebkit&&!cap.isios&&!cap.isandroid) {
       this.istouchcapable = true;
       cap.cantouch = false;  // parse normal desktop events
     }    


### PR DESCRIPTION
While having a look at https://bugs.webkit.org/show_bug.cgi?id=129680, Diego Pino (dpino@igalia.com) and Enrique Ocaña (eocanha@igalia.com) realized that nicescroll was detecting WebKitGTK+ running on desktop as having "cantouch" capabilities. WebKitGTK+ and, in general, all WebKit based browsers, should have the same treatment as Chrome.
