### PR TITLE
Fix for neverending drag mode on horizontal scrollbar disappear

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -1274,7 +1274,12 @@
           self.onmousemove = function(e) {
             if (self.rail.drag) {
               if(self.rail.drag.pt!=1)return;
-              
+
+              if (!self.rail.visibility && !self.railh.visibility) {
+                self.rail.drag = false;
+                return;
+              }
+
               if (cap.ischrome&&e.which==0) return self.onmouseup(e);
               
               self.cursorfreezed = true;


### PR DESCRIPTION
If you have a horizontal scrollbar (and no vertical) which can only scroll a few pixel it dissapears on dragging it in Firefox. In this case the drag mode is not disabled and every time the mouse is moved it is interpreted as a drag and focus is removed from the current active element.
