### PR TITLE
Windows 8.1 IE11 pointerType change

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -994,7 +994,7 @@
             self.scrollmom = new ScrollMomentumClass2D(self);
           
             self.ontouchstart = function(e) {
-              if (e.pointerType&&e.pointerType!=2) return false;
+              if (e.pointerType&&e.pointerType!=2&&e.pointerType!="touch") return false;
               
 							self.hasmoving = false;
 							
@@ -1097,7 +1097,7 @@
             };
             
             self.ontouchend = function(e) {
-              if (e.pointerType&&e.pointerType!=2) return false;
+              if (e.pointerType&&e.pointerType!=2&&e.pointerType!="touch") return false;
               if (self.rail.drag&&(self.rail.drag.pt==2)) {
                 self.scrollmom.doMomentum();
                 self.rail.drag = false;
@@ -1115,7 +1115,7 @@
             
             self.ontouchmove = function(e,byiframe) {
               
-              if (e.pointerType&&e.pointerType!=2) return false;
+              if (e.pointerType&&e.pointerType!=2&&e.pointerType!="touch") return false;
     
               if (self.rail.drag&&(self.rail.drag.pt==2)) {
                 if (cap.cantouch&&(typeof e.original == "undefined")) return true;  // prevent ios "ghost" events by clickable elements


### PR DESCRIPTION
We had a problem on Windows Surface RT, this few modification solved it for us. I found out that after windows 8, Microsoft had changed the event.pointerType from long to string. So now is has type 'any', as it is written here: http://msdn.microsoft.com/en-us/library/windows/apps/hh466130.aspx
This modification solves the problem on IE11 - windows 8.1
