### PR TITLE
Fixed bug: #511 Unable to get property 'delaylist' of undefined or nu…

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -385,6 +385,9 @@
       self.delaylist[name] = fn;
       if (!dd) {
         setTimeout(function() {
+          if(!self) {
+            return;
+          }
           var fn = self.delaylist[name];
           self.delaylist[name] = false;
           fn.call(self);


### PR DESCRIPTION
#511:  "Unable to get property 'delaylist' of undefined or null reference" error when the nicescroll container is removed

If the nice scroll is on a container what is added/removed dynamically from the dom, our users experiences sometimes the following error on console:
"Unable to get property 'delaylist' of undefined or null reference"

There are edge cases where the settimeout runs when the element is already removed form the dom and "self" no longer contains a valid reference.