### PR TITLE
Background Parallax Fix

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -555,7 +555,7 @@
         return self.docscroll.scrollTop();
       };
       this.setScrollTop = function(val) {
-        return self.docscroll.scrollTop(val);
+        return setTimeout(function() {self.docscroll.scrollTop(val)}, 1);
       };
       this.getScrollLeft = function() {
         if (self.detected.ismozilla && self.isrtlmode)
@@ -563,7 +563,7 @@
         return self.docscroll.scrollLeft();
       };
       this.setScrollLeft = function(val) {
-        return self.docscroll.scrollLeft((self.detected.ismozilla && self.isrtlmode) ? -val : val);
+        return setTimeout(function() {self.docscroll.scrollLeft((self.detected.ismozilla && self.isrtlmode) ? -val : val)}, 1);
       };
     }
 


### PR DESCRIPTION
Fix for when nicescroll uses native scrolling mode and combined with parallax type of script that moves image background position value via js scroll event resulting in image movement choppy or jumpy in chrome and webkit related browsers.
Adding 1 miliseconds timeout before firing the screen movement.