### PR TITLE
Reset checkarea for mouse wheel event when the mouse moved

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -1484,11 +1484,9 @@
 
               return self.cancelEvent(e);
             }
-            /*              
             else {
-              self.checkarea = true;
+              self.checkarea = 0;
             }
-*/
           };
 
           if (cap.cantouch || self.opt.touchbehavior) {


### PR DESCRIPTION
The onmousewheel event checks under the mouse pointer every 600ms to find if it hovers a scrollable element. If it finds a nicescrollable element, it locks on it for the next 600ms.

This causes a noticeable delay if the user moves the mouse between two scrollable elements.

For a reason I do not know, there was a bit of commented code that used to reset self.checkarea. Uncommenting that else block, and resetting self.checkarea to zero removes the delay, and doesn't affect the optimization too much.

This PR fixes #535 