### PR TITLE
add "main" attribute to package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/inuyaksa/jquery.nicescroll"
   },
-  "main": "./jquery.nicescroll.min.js",
+  "main": "./dist/jquery.nicescroll.min.js",
   "title": "jQuery.NiceScroll",
   "author": {
     "name": "InuYaksa",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/inuyaksa/jquery.nicescroll"
   },
+  "main": "./jquery.nicescroll.min.js",
   "title": "jQuery.NiceScroll",
   "author": {
     "name": "InuYaksa",


### PR DESCRIPTION
Missing "main" attribute in package.json so browserify wasn't working with the library. I added "main" attribute to package.json for Node / CommonJS specifications.