### PR TITLE
Fixing nicescroll visibility inside Modal

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -1895,7 +1895,7 @@
           self.observerbody = new ClsMutationObserver(function(mutations) {
             mutations.forEach(function(mut){
               if (mut.type=="attributes") {
-                return ($("body").hasClass("modal-open")) ? self.hide() : self.show();  // Support for Bootstrap modal
+                return ($("body").hasClass("modal-open") && !$.contains($('.modal-dialog')[0],self.doc[0])) ? self.hide() : self.show();  // Support for Bootstrap modal; Added check if the nice scroll element is inside a modal
               }
             });  
             if (document.body.scrollHeight!=self.page.maxh) return self.lazyResize(30);


### PR DESCRIPTION
Due to check at line 1898, the nicescroll was being hidden inside a modal.
Added check if the nice scroll element is inside a modal, in that case the nice scroll should not be hidden.