### PR TITLE
Fixed timing bug in this.synched function

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -404,6 +404,7 @@
       function requestSync() {
         if (_onsync) return;
         setAnimationFrame(function() {
+          if (!self) return;
           _onsync = false;
           for (var nn in self.synclist) {
             var fn = self.synclist[nn];


### PR DESCRIPTION
Fixes the case where the `remove` function is called which sets `self` to null and then a function passed to `setAnimationFrame` is called asynchronously.