### PR TITLE
mousewheel no element dosen't work well when element.parentNode is scrollable

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -2647,7 +2647,7 @@
     this.isScrollable = function(e) {
       var dom = (e.target) ? e.target : e;
       if (dom.nodeName == 'OPTION') return true;
-      while (dom && (dom.nodeType == 1) && !(/^BODY|HTML/.test(dom.nodeName))) {
+      while (dom && (dom.nodeType == 1) && (dom !== this.me[0]) && !(/^BODY|HTML/.test(dom.nodeName))) {
         var dd = $(dom);
         var ov = dd.css('overflowY') || dd.css('overflowX') || dd.css('overflow') || '';
         if (/scroll|auto/.test(ov)) return (dom.clientHeight != dom.scrollHeight);


### PR DESCRIPTION
When element.parentNode is defined `overflow-y: auto;` and element height greater than element.parentNode height, then define `$(element).niceScroll()`, the niceScroll can not scroll when mousewheel on the element

So `isScrollable` method add `dom !== this.me[0]` in the while condition, fixed this problem
