### PR TITLE
Remove Invalid 'main' Entry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,7 @@
 {
     "name": "jquery.nicescroll",
     "main": [
-        "./jquery.nicescroll.js",
-        "./zoomico.png"
+        "./jquery.nicescroll.js"
     ],
     "ignore": [
         "**/.*",


### PR DESCRIPTION
**Error:**

> bower jquery.nicescroll#*
> invalid-meta
> The "main" field cannot contain font, image, audio, or video files

**Per the ['main'](https://github.com/bower/spec/blob/master/json.md#main) documentation:**

> Image and font files may be used or referenced within the JS or Sass files, but are not 'main' files as they are not entry-points.
> Do not include assets files like images, fonts, audio, or video
