### PR TITLE
stops vertical bar from flashing on load

### DIFF
--- a/dist/jquery.nicescroll.js
+++ b/dist/jquery.nicescroll.js
@@ -2303,7 +2303,7 @@
       if (!self.hasborderbox) self.scrollvaluemax -= self.cursor[0].offsetHeight - self.cursor[0].clientHeight;
 
       if (self.railh) {
-        self.railh.width = (self.page.maxh > 0) ? (self.view.w - self.rail.width) : self.view.w;
+        self.railh.width = (self.page.maxh > 0) ? (self.rail.width) : self.view.w;
         self.scrollvaluemaxw = self.railh.width - self.cursorwidth - (opt.railpadding.left + opt.railpadding.right);
       }
 


### PR DESCRIPTION
While using loading-bar.js I noticed a bar flashing on the screen (1680x1050). I traced the issue back to a div with class nicescroll-rails and id  ascrail2000. It seems on larger monitors this doesn't get set to the proper width.