### PR TITLE
Added Additional Check for Mac

### DIFF
--- a/jquery.nicescroll.js
+++ b/jquery.nicescroll.js
@@ -174,7 +174,7 @@
     d.hasw3ctouch = (_win.PointerEvent || false) && ((navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)); //IE11 pointer events, following W3C Pointer Events spec
     d.hasmstouch = (!d.hasw3ctouch) && (_win.MSPointerEvent || false); // IE10 pointer events
 
-    d.ismac = /^mac$/i.test(_platform);
+    d.ismac = /^mac$/i.test(_platform) || /^MacIntel$/i.test(_platform);
 
     d.isios = d.cantouch && /iphone|ipad|ipod/i.test(_platform);
     d.isios4 = d.isios && !("seal" in Object);


### PR DESCRIPTION
In some Mac's like mine (MacBook Pro 2011) the `navigator.platform` property is `MacIntel` instead of `mac` thus the check `d.ismac = /^mac$/i.test(_platform)` returns `false`. Thus an extra check has been added.